### PR TITLE
Variable cleanup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,22 +1,12 @@
 #!/bin/bash
 set -e
 
-# References:
-
-MAJOR_RELEASE=11.2.0
 WORKDIR=~/icpc
-ORIG_CD=${WORKDIR}/original-cd
-NEW_CD=${WORKDIR}/cd
-CUSTOM=${WORKDIR}/custom
-SQUASHFS=${WORKDIR}/squashfs
 PACKAGES="build-essential emacs neovim code openjdk-17-jdk-headless python2.7 python3.5"
 ECLIPSE_RELEASE=2021-12
 
 # Hopefully nothing to change below this line
 
-ISO_URL_BASE=https://cdimage.debian.org/debian-cd/${MAJOR_RELEASE}-live/amd64/iso-hybrid
-ISO_URL=${ISO_URL_BASE}/debian-live-${MAJOR_RELEASE}-amd64-xfce.iso
-MKISOFS_OPTIONS="-b isolinux/isolinux.bin -c isolinux/boot.cat -cache-inodes -J -l -no-emul-boot -boot-load-size 4 -boot-info-table"
 ECLIPSE_URL_BASE=https://mirror.umd.edu/eclipse/technology/epp/downloads/release
 ECLIPSE_CPP_URL=${ECLIPSE_URL_BASE}/${ECLIPSE_RELEASE}/R/eclipse-cpp-${ECLIPSE_RELEASE}-R-linux-gtk-x86_64.tar.gz
 ECLIPSE_JAVA_URL=${ECLIPSE_URL_BASE}/${ECLIPSE_RELEASE}/R/eclipse-java-${ECLIPSE_RELEASE}-R-linux-gtk-x86_64.tar.gz

--- a/debian-live/config/hooks/live/enable-shorewall.chroot
+++ b/debian-live/config/hooks/live/enable-shorewall.chroot
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+systemctl enable shorewall

--- a/debian-live/config/hooks/live/enable-shorewall.chroot
+++ b/debian-live/config/hooks/live/enable-shorewall.chroot
@@ -1,3 +1,0 @@
-#!/bin/sh
-set -e
-systemctl enable shorewall

--- a/debian-live/config/includes.chroot/lib/live/config/9999-enable-start-shorewall.hook.chroot
+++ b/debian-live/config/includes.chroot/lib/live/config/9999-enable-start-shorewall.hook.chroot
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+systemctl enable shorewall
+systemctl start shorewall

--- a/debian-live/config/includes.chroot/lib/live/config/9999-enable-start-shorewall.hook.chroot
+++ b/debian-live/config/includes.chroot/lib/live/config/9999-enable-start-shorewall.hook.chroot
@@ -1,4 +1,3 @@
 #!/bin/sh
 set -e
-systemctl enable shorewall
-systemctl start shorewall
+shorewall start


### PR DESCRIPTION
Cleaning up unneeded variables, starting Shorewall automatically on boot.

TODO: figure out why `systemctl enable shorewall` didn't work, and see if it's possible to use a network printer.